### PR TITLE
Hard blur/refocus when saving title.

### DIFF
--- a/birch-artifact-list-item.html
+++ b/birch-artifact-list-item.html
@@ -351,6 +351,9 @@ Example:
         if (displayMessage) return true;
         return count > 0;
       },
+      /* 
+        * Takes focus away from input, so keyboard closes on mobile devices.
+      */
       _focusTitle: function() {
         document.activeElement.blur();
         this.$$('.title-text').focus();

--- a/birch-artifact-list-item.html
+++ b/birch-artifact-list-item.html
@@ -305,16 +305,16 @@ Example:
         this._stopProp(e);
         if ((e.keyCode == 13 || e.key == "Enter" || e.type == "blur") && e.currentTarget.value.length > 0) {
           this._saveTitle(e.currentTarget.value);
-          this.blur();
+          this._focusTitle();
         } else if ((e.keyCode == 13 || e.key == "Enter" || e.type == "blur") && e.currentTarget.value.length == 0) { 
           this._titleInputActive = false;
-          this.blur();
+          this._focusTitle();
         } else if (e.keyCode === 27) {
           // Handle exit key
           e.currentTarget.value = "";
           this.set('data.title', "");
           this._titleInputActive = false;
-          this.blur();
+          this._focusTitle();
         }
       },
       _getPlace: function(datesPlaces) {
@@ -350,6 +350,10 @@ Example:
       _hideTag: function(count, displayMessage) {
         if (displayMessage) return true;
         return count > 0;
+      },
+      _focusTitle: function() {
+        document.activeElement.blur();
+        this.$$('.title-text').focus();
       },
       _goToArtifact: function(e) {
         if (this.selectMode) return;


### PR DESCRIPTION
- On IOS, the keyboard was not closing down because the input even was still focused, despite it being hidden.
- On Safari, the blur event was firing after saving a title because the input was still focused even though it was hidden.
- This code guarantees the input will be blurred when a title is saved, and as a safety, another element is selected to guarantee the input is no longer active.