### PR TITLE
Pass cis

### DIFF
--- a/birch-artifact-list-item.html
+++ b/birch-artifact-list-item.html
@@ -82,8 +82,8 @@ Example:
                 </a>
               </template>
             </div>
-            <div class="contributor" title='[[data.ftUserInfo.contactName]]'>
-              <span></span>[[_translateContributor(_contributedBy)]] <span class='contributor-name' on-tap='_openContactCard'>[[data.ftUserInfo.contactName]]</span>
+            <div class="contributor" title='[[_getContactName(data)]]'>
+              <span></span>[[_translateContributor(_contributedBy)]] <span class='contributor-name' on-tap='_openContactCard'>[[_getContactName(data)]]</span>
             </div>
           </div>
         </div>
@@ -531,7 +531,7 @@ Example:
       _openContactCard: function(e) {
         e.stopPropagation();
         this.fire('gallery-close-contact-card',{});
-        var contactData = {'event': e, 'data': this.data.ftUserInfo }
+        var contactData = {'event': e, 'cisId': this.data.contributorCisUserId  }
         this.fire('gallery-open-contact-card', contactData);
       },
        _openInfoDialog: function(e) {
@@ -548,7 +548,10 @@ Example:
       _isOwner: function(experiment, user, contributor, restricted) {
         if (!restricted || !experiment) return false;
         return (user === contributor);
-      }
+      },
+      _getContactName: function(data) {
+        return data.contributorContactName || data.ftUserInfo.contactName
+     }
     });
   </script>
 </dom-module>

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-artifact-list-item",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "authors": [
     "Matthew Liechty <matthew@liechty.org>"
   ],


### PR DESCRIPTION
### Summary
We will soon be using MPS instead of Memories AMI to get the contributor contact name. These changes prepare us to use this new endpoint.

### Changes
- The new endpoint will send the data back in a flattened format so `_getContactName` allows for this.
- When the user clicks on the contributor name, pass the cis id to for the `birch-contact-card` to consume
- Updated bower version
