### PR TITLE
Change add to album to return an object instead of array

### DIFF
--- a/birch-artifact-list-item-preview.html
+++ b/birch-artifact-list-item-preview.html
@@ -136,7 +136,7 @@
           this._handleUploadError(result.err);
           return;
         }
-        var artifact = (Array.isArray(result)) ? result[0] : result.artifact;
+        var artifact = (Array.isArray(result.items)) ? result.items[0] : result.artifact;
         var thumbSquareUrl = result.artifact ? result.artifact.thumbSquareUrl : null;
         artifact.thumbUrl = this.data.thumbUrl || thumbSquareUrl;
         if(!this.data.thumbUrl){

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-artifact-list-item",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "authors": [
     "Matthew Liechty <matthew@liechty.org>"
   ],


### PR DESCRIPTION
### Changes
- Changing the data structure returned by `_execAddToAlbum` to be an array wrapped in an object instead of just returning an array.  This is being done to fix a bug that occurs when the `noAlbumSort` and `actionsMenuEx` experiments are both turned on.

@jpodwys / @chadeddington / @dcravenus 